### PR TITLE
Fix document attributes and references for compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-.PHONY: update clean publish
+.PHONY: all update clean publish
 
 SOURCES := draft-gold-acvp-iana.adoc draft-gold-acvp-protocol-spec.adoc draft-gold-acvp-sub-drbg.adoc draft-gold-acvp-sub-kdf108.adoc draft-gold-acvp-sub-kdf135-ikev1.adoc draft-gold-acvp-sub-kdf135-ikev2.adoc draft-gold-acvp-sub-kdf135-snmp.adoc draft-gold-acvp-sub-kdf135-x942.adoc draft-gold-acvp-sub-kdf135-x963.adoc draft-gold-acvp-sub-mac.adoc draft-gold-acvp-sub-pbkdf.adoc draft-gold-acvp-sub-sha.adoc draft-gold-acvp-sub-sha3.adoc
 HTML 	:= $(patsubst %.adoc, %.html, $(SOURCES))
 TXT 	:= $(patsubst %.adoc, %.txt,  $(SOURCES))
+
+all: $(HTML) $(TXT)
 
 update:
 	bundle install
@@ -10,15 +12,10 @@ update:
 clean:
 	rm -rf *.err *.html *.xml *.txt documents/
 
-%.html: %.adoc
-	metanorma compile -t ietf -x html $<
-
-%.txt: %.adoc
-	metanorma compile -t ietf -x txt $<
+%.html %.txt: %.adoc
+	bundle exec metanorma compile $<
 
 publish:
 	mkdir -p documents
 	mv *.html documents/
 	mv *.txt documents/
-
-all: $(HTML) $(TXT)

--- a/ans9.42/sections/98-references.adoc
+++ b/ans9.42/sections/98-references.adoc
@@ -9,6 +9,8 @@
 [%bibitem]
 === Automatic Cryptographic Validation Protocol
 id:: ACVP
+docid::
+  id::: ACVP
 contributor::
 contributor.person.name.initial:: B.
 contributor.person.name.surname:: Fussell

--- a/ans9.63/sections/98-references.adoc
+++ b/ans9.63/sections/98-references.adoc
@@ -9,6 +9,8 @@
 [%bibitem]
 === Automatic Cryptographic Validation Protocol
 id:: ACVP
+docid::
+  id::: ACVP
 contributor::
 contributor.person.name.initial:: B.
 contributor.person.name.surname:: Fussell

--- a/draft-gold-acvp-iana.adoc
+++ b/draft-gold-acvp-iana.adoc
@@ -142,6 +142,8 @@ Security considerations are addressed by the ACVP specification.
 [%bibitem]
 === Automatic Cryptographic Validation Protocol
 id:: ACVP
+docid::
+  id::: ACVP
 contributor::
 contributor.person.name.initial:: B.
 contributor.person.name.surname:: Fussell
@@ -167,6 +169,8 @@ date.value:: 2019-07-01
 [%bibitem]
 === ACVP Symmetric Algorithm JSON Specification
 id:: Sub-symmetric
+docid::
+  id::: ACVP-Symmetric
 
 // <reference anchor="Sub-symmetric">
 //   <front>

--- a/draft-gold-acvp-iana.adoc
+++ b/draft-gold-acvp-iana.adoc
@@ -1,15 +1,13 @@
 = ACVP IANA Registry
 :doctype: internet-draft
-:docname: acvp-iana
-:name: draft-ietf-acvp-iana-1.0
+:docnumber: draft-ietf-acvp-iana-01
 :abbrev: ACVP IANA
-:status: informational
 :ipr: trust200902
 :submission-type: independent
+:intended-series: informational
 :area: Internet
-:intended-series: info
 :revdate: 2019-06-05
-:forename_initials: A.V.
+:initials: A.V.
 :lastname: Vassilev
 :fullname: Apostol Vassilev
 :organization: National Institute of Standards and Technology
@@ -20,10 +18,8 @@
 :email: apostol.vassilev@nist.gov
 :docfile: draft-gold-acvp-iana.adoc
 :role: editor
-
 :mn-document-class: ietf
 :mn-output-extensions: xml,rfc,txt,html
-
 :area: General
 :keyword: acvp, crypto
 

--- a/draft-gold-acvp-protocol-spec.adoc
+++ b/draft-gold-acvp-protocol-spec.adoc
@@ -1,14 +1,12 @@
-
 = Automated Cryptographic Validation Protocol (ACVP) JSON Specification
 :doctype: internet-draft
 :docname: acvp-spec
-:name: draft-ietf-acvp-spec-1.0
+:docnumber: draft-ietf-acvp-spec-01
 :abbrev: ACVP Protocol
-:status: informational
 :ipr: trust200902
 :submission-type: independent
 :area: Internet
-:intended-series: info
+:intended-series: informational
 :revdate: 2019-01-01
 :forename_initials: B.F.
 :lastname: Fussell
@@ -20,7 +18,7 @@
 :country: United States of America
 :email: bfussell@cisco.com
 :role: editor
-:forename_initials_2: A.V.
+:initials_2: A.V.
 :lastname_2: Vassilev
 :fullname_2: Apostol Vassilev
 :organization_2: National Institute of Standards and Technology
@@ -30,7 +28,7 @@
 :country_2: United States of America
 :email_2: apostol.vassilev@nist.gov
 :role_2: editor
-:forename_initials_3: H.B.
+:initials_3: H.B.
 :lastname_3: Booth
 :fullname_3: Harold Booth
 :organization_3: National Institute of Standards and Technology
@@ -40,10 +38,8 @@
 :country_3: United States of America
 :email_3: harold.booth@nist.gov
 :role_3: editor
-
 :mn-document-class: ietf
 :mn-output-extensions: xml,rfc,txt,html
-
 :area: General
 :keyword: acvp, template
 

--- a/draft-gold-acvp-sub-drbg.adoc
+++ b/draft-gold-acvp-sub-drbg.adoc
@@ -1,13 +1,12 @@
 = ACVP Deterministic Random Bit Generator (DRBG) Algorithm JSON Specification
 :doctype: internet-draft
 :docname: acvp-drbg
-:name: draft-vassilev-acvp-drbg-00
+:docnumber: draft-vassilev-acvp-drbg-00
 :abbrev: ACVP DRBG
-:status: informational
 :ipr: trust200902
 :submission-type: independent
 :area: Internet
-:intended-series: info
+:intended-series: informational
 :revdate: 2019-06-05
 :forename_initials: A.V.
 :lastname: Vassilev

--- a/draft-gold-acvp-sub-kdf108.adoc
+++ b/draft-gold-acvp-sub-kdf108.adoc
@@ -1,14 +1,12 @@
-
 = ACVP SP800-108 Key Derivation Function JSON Specification
 :doctype: internet-draft
 :docname: acvp-kdf
-:name: draft-gold-acvp-kdf-1.0
+:docnumber: draft-gold-acvp-kdf-01
 :abbrev: ACVP KDFs
-:status: informational
 :ipr: trust200902
 :submission-type: independent
 :area: Internet
-:intended-series: info
+:intended-series: informational
 :revdate: 2019-06-05
 :forename_initials: C.C.
 :lastname: Celi

--- a/draft-gold-acvp-sub-kdf135-ikev1.adoc
+++ b/draft-gold-acvp-sub-kdf135-ikev1.adoc
@@ -1,13 +1,12 @@
 = ACVP IKEv1 Key Derivation Function JSON Specification
 :doctype: internet-draft
 :docname: acvp-ikev1
-:name: draft-gold-acvp-kdf-ikev1-1.0
+:docnumber: draft-gold-acvp-kdf-ikev1-01
 :abbrev: ACVP KDF IKEv1
-:status: informational
 :ipr: trust200902
 :submission-type: independent
 :area: Internet
-:intended-series: info
+:intended-series: informational
 :revdate: 2019-06-05
 :forename_initials: C. C.
 :lastname: Celi

--- a/draft-gold-acvp-sub-kdf135-ikev2.adoc
+++ b/draft-gold-acvp-sub-kdf135-ikev2.adoc
@@ -1,13 +1,12 @@
 = ACVP IKEv2 Key Derivation Function JSON Specification
 :doctype: internet-draft
 :docname: acvp-ikev2
-:name: draft-gold-acvp-kdf-ikev2-1.0
+:docnumber: draft-gold-acvp-kdf-ikev2-01
 :abbrev: ACVP KDF IKEv2
-:status: informational
 :ipr: trust200902
 :submission-type: independent
 :area: Internet
-:intended-series: info
+:intended-series: informational
 :revdate: 2019-06-05
 :forename_initials: C. C.
 :lastname: Celi

--- a/draft-gold-acvp-sub-kdf135-snmp.adoc
+++ b/draft-gold-acvp-sub-kdf135-snmp.adoc
@@ -1,13 +1,12 @@
 = ACVP SNMP Key Derivation Function JSON Specification
 :doctype: internet-draft
 :docname: acvp-snmp
-:name: draft-gold-acvp-sub-kdf135-snmp-1.0
+:docnumber: draft-gold-acvp-sub-kdf135-snmp-01
 :abbrev: ACVP KDF SNMP
-:status: informational
 :ipr: trust200902
 :submission-type: independent
 :area: Internet
-:intended-series: info
+:intended-series: informational
 :revdate: 2019-06-05
 :forename_initials: C.C.
 :lastname: Celi

--- a/draft-gold-acvp-sub-kdf135-x942.adoc
+++ b/draft-gold-acvp-sub-kdf135-x942.adoc
@@ -1,13 +1,12 @@
 = ACVP ANS x9.42 Key Derivation Function JSON Specification
 :doctype: internet-draft
 :docname: acvp-x942
-:name: draft-gold-acvp-sub-kdf135-x942-00
+:docnumber: draft-gold-acvp-sub-kdf135-x942-00
 :abbrev: ACVP ANS x9.42 KDF
-:status: informational
 :ipr: trust200902
 :submission-type: independent
 :area: Internet
-:intended-series: info
+:intended-series: informational
 :revdate: 2019-06-05
 :fullname: Christopher Celi
 :lastname: Celi

--- a/draft-gold-acvp-sub-kdf135-x963.adoc
+++ b/draft-gold-acvp-sub-kdf135-x963.adoc
@@ -1,13 +1,12 @@
 = ACVP ANS X9.63 Key Derivation Function Algorithm JSON Specification
 :doctype: internet-draft
 :docname: acvp-x963
-:name: draft-fussell-acvp-ans-x963-00
+:docnumber: draft-fussell-acvp-ans-x963-00
 :abbrev: ACVP ANS x9.63 KDF
-:status: informational
 :ipr: trust200902
 :submission-type: independent
 :area: Internet
-:intended-series: info
+:intended-series: informational
 :revdate: 2019-06-05
 :forename_initials: B.F.
 :lastname: Fussell

--- a/draft-gold-acvp-sub-mac.adoc
+++ b/draft-gold-acvp-sub-mac.adoc
@@ -1,14 +1,12 @@
-
 = ACVP Message Authentication Algorithm JSON Specification
 :doctype: internet-draft
 :docname: acvp-mac
-:name: draft-ietf-acvp-sub-mac-1.0
+:docnumber: draft-ietf-acvp-sub-mac-01
 :abbrev: ACVP MAC
-:status: informational
 :ipr: trust200902
 :submission-type: independent
 :area: Internet
-:intended-series: info
+:intended-series: informational
 :revdate: 2018-08-01
 :forename_initials: B.F.
 :lastname: Fussell
@@ -20,7 +18,7 @@
 :country: United States of America
 :email: bfussell@cisco.com
 :role: editor
-:forename_initials_2: R.H.
+:initials_2: R.H.
 :lastname_2: Hammett
 :fullname_2: Russell Hammett
 :organization_2: G2, Inc.

--- a/draft-gold-acvp-sub-pbkdf.adoc
+++ b/draft-gold-acvp-sub-pbkdf.adoc
@@ -1,13 +1,12 @@
 = ACVP Password-based Key Derivation Function JSON Specification
 :doctype: internet-draft
 :docname: acvp-pbkdf
-:name: draft-gold-acvp-pbkdf-01
+:docnumber: draft-gold-acvp-pbkdf-01
 :abbrev: ACVP PBKDF
-:status: informational
 :ipr: trust200902
 :submission-type: independent
 :area: Internet
-:intended-series: info
+:intended-series: informational
 :revdate: 2019-06-05
 :forename_initials: C.C.
 :lastname: Celi

--- a/draft-gold-acvp-sub-sha.adoc
+++ b/draft-gold-acvp-sub-sha.adoc
@@ -1,13 +1,12 @@
 = ACVP Secure Hash Algorithm (SHA) JSON Specification
 :doctype: internet-draft
 :docname: acvp-sha
-:name: draft-ietf-acvp-sub-sha-1.0
+:docnumber: draft-ietf-acvp-sub-sha-01
 :abbrev: ACVP SHA
-:status: informational
 :ipr: trust200902
 :submission-type: independent
 :area: Internet
-:intended-series: info
+:intended-series: informational
 :revdate: 2018-11-01
 :forename_initials: C.C.
 :lastname: Celi

--- a/draft-gold-acvp-sub-sha3.adoc
+++ b/draft-gold-acvp-sub-sha3.adoc
@@ -1,13 +1,12 @@
 = ACVP SHA3 and SHAKE JSON Specification
 :doctype: internet-draft
 :docname: acvp-sha3
-:name: draft-ietf-acvp-sub-sha3-1.0
+:docnumber: draft-ietf-acvp-sub-sha3-01
 :abbrev: ACVP SHA3
-:status: informational
 :ipr: trust200902
 :submission-type: independent
 :area: General
-:intended-series: info
+:intended-series: informational
 :revdate: 2018-11-01
 :forename_initials: C.C.
 :lastname: Celi

--- a/drbg/sections/98-references.adoc
+++ b/drbg/sections/98-references.adoc
@@ -9,6 +9,8 @@
 [%bibitem]
 === Automatic Cryptographic Validation Protocol
 id:: ACVP
+docid::
+  id::: ACVP
 contributor::
 contributor.person.name.initial:: B.
 contributor.person.name.surname:: Fussell
@@ -37,3 +39,5 @@ date.value:: 2019-07-01
 [%bibitem]
 === SP800-90A Spec
 id:: SP800-90A
+docid::
+  id::: NIST SP 800-90A

--- a/ikev1/sections/98-references.adoc
+++ b/ikev1/sections/98-references.adoc
@@ -9,6 +9,8 @@
 [%bibitem]
 === Automatic Cryptographic Validation Protocol
 id:: ACVP
+docid::
+  id::: ACVP
 contributor::
 contributor.person.name.initial:: B.
 contributor.person.name.surname:: Fussell

--- a/ikev2/sections/98-references.adoc
+++ b/ikev2/sections/98-references.adoc
@@ -9,6 +9,8 @@
 [%bibitem]
 === Automatic Cryptographic Validation Protocol
 id:: ACVP
+docid::
+  id::: ACVP
 contributor::
 contributor.person.name.initial:: B.
 contributor.person.name.surname:: Fussell

--- a/kdf/sections/98-references.adoc
+++ b/kdf/sections/98-references.adoc
@@ -9,6 +9,8 @@
 [%bibitem]
 === Automatic Cryptographic Validation Protocol
 id:: ACVP
+docid::
+  id::: ACVP
 contributor::
 contributor.person.name.initial:: B.
 contributor.person.name.surname:: Fussell

--- a/mac/sections/98-references.adoc
+++ b/mac/sections/98-references.adoc
@@ -9,6 +9,8 @@
 [%bibitem]
 === Automatic Cryptographic Validation Protocol
 id:: ACVP
+docid::
+  id::: ACVP
 contributor::
 contributor.person.name.initial:: B.
 contributor.person.name.surname:: Fussell
@@ -37,6 +39,8 @@ date.value:: 2019-07-01
 [%bibitem]
 === The CMAC Validation System (CMACVS)
 id:: CMACVS
+docid::
+  id::: NIST CMACVS
 
 // <reference anchor="CMACVS">
 //   <front>
@@ -53,6 +57,8 @@ id:: CMACVS
 [%bibitem]
 === The Keyed-Hash Message Authentication Code (HMAC)
 id:: FIPS-198-1
+docid::
+  id::: FIPS 198-1
 
 // <reference anchor="FIPS-198-1" target="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.198-1.pdf">
 //   <front>
@@ -69,6 +75,8 @@ id:: FIPS-198-1
 [%bibitem]
 === The Keyed-Hash Message Authentication Code Validation System (HMACVS)
 id:: HMACVS
+docid::
+  id::: NIST HMACVS
 
 // <reference anchor="HMACVS">
 //   <front>
@@ -85,6 +93,8 @@ id:: HMACVS
 [%bibitem]
 === The Secure Hash Algorithm 3 Validation System (SHA3VS)
 id:: SHA3VS
+docid::
+  id::: NIST SHA3VS
 
 // <reference anchor="SHA3VS">
 //   <front>
@@ -101,6 +111,8 @@ id:: SHA3VS
 [%bibitem]
 === The Secure Hash Algorithm Validation System (SHAVS)
 id:: SHAVS
+docid::
+  id::: NIST SHAVS
 
 // <reference anchor="SHAVS">
 //   <front>
@@ -117,6 +129,8 @@ id:: SHAVS
 [%bibitem]
 === Recommendation for Block Cipher Modes of Operation: The CMAC Mode for Authentication
 id:: SP-800-38B
+docid::
+  id::: NIST SP 800-38B
 
 // <reference anchor="SP-800-38B" target="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-38b.pdf">
 //   <front>
@@ -133,6 +147,8 @@ id:: SP-800-38B
 [%bibitem]
 === Recommendation for Block Cipher Modes of Operation: Galois/Counter Mode (GCM) and GMAC
 id:: SP-800-38D
+docid::
+  id::: NIST SP 800-38D
 
 // <reference anchor="SP-800-38D" target="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf">
 //   <front>

--- a/pbkdf/sections/98-references.adoc
+++ b/pbkdf/sections/98-references.adoc
@@ -9,6 +9,8 @@
 [%bibitem]
 === Automatic Cryptographic Validation Protocol
 id:: ACVP
+docid::
+  id::: ACVP
 contributor::
 contributor.person.name.initial:: B.
 contributor.person.name.surname:: Fussell

--- a/protocol/sections/98-references.adoc
+++ b/protocol/sections/98-references.adoc
@@ -48,7 +48,7 @@ docid::
   id::: NIST ACVP Symmetric Algorithm JSON Specification
 contributor::
 contributor.person.name.initial:: C.
-contributor.person.name.surname:: CELI
+contributor.person.name.surname:: Celi
 contributor.person.affiliation.organization.name:: NIST
 date::
 date.type:: published

--- a/protocol/sections/98-references.adoc
+++ b/protocol/sections/98-references.adoc
@@ -18,6 +18,8 @@
 [%bibitem]
 === ACVP IANA Registry
 id:: acvp-iana
+docid::
+  id::: NIST ACVP IANA Registry
 contributor::
 contributor.person.name.initial:: A.
 contributor.person.name.surname:: Vassilev
@@ -29,6 +31,8 @@ date.value:: 2018-11-01
 [%bibitem]
 === Cryptographic Algorithm Validation Program
 id:: cavp
+docid::
+  id::: NIST CAVP
 contributor::
 contributor.person.name.initial:: A.
 contributor.person.name.surname:: Vassilev
@@ -40,6 +44,8 @@ date.value:: 2018-02
 [%bibitem]
 === ACVP Symmetric Algorithm JSON Specification
 id:: sub-symmetric
+docid::
+  id::: NIST ACVP Symmetric Algorithm JSON Specification
 contributor::
 contributor.person.name.initial:: C.
 contributor.person.name.surname:: CELI

--- a/sha/sections/98-references.adoc
+++ b/sha/sections/98-references.adoc
@@ -9,6 +9,8 @@
 [%bibitem]
 === Automatic Cryptographic Validation Protocol
 id:: ACVP
+docid::
+  id::: ACVP
 contributor::
 contributor.person.name.initial:: B.
 contributor.person.name.surname:: Fussell
@@ -37,6 +39,8 @@ date.value:: 2019-07-01
 [%bibitem]
 === Secure Hash Standard (SHS)
 id:: FIPS180-4
+docid::
+  id::: FIPS 180-4
 
 // <reference anchor="FIPS180-4" target="https://csrc.nist.gov/csrc/media/publications/fips/180/4/archive/2012-03-06/documents/fips180-4.pdf">
 //   <front>
@@ -53,6 +57,8 @@ id:: FIPS180-4
 [%bibitem]
 === The Secure Hash Algorithm Validation System (SHAVS)
 id:: SHAVS
+docid::
+  id::: NIST SHAVS
 
 // <reference anchor="SHAVS">
 //   <front>

--- a/sha3/sections/98-references.adoc
+++ b/sha3/sections/98-references.adoc
@@ -9,6 +9,8 @@
 [%bibitem]
 === Automatic Cryptographic Validation Protocol
 id:: ACVP
+docid::
+  id::: ACVP
 contributor::
 contributor.person.name.initial:: B.
 contributor.person.name.surname:: Fussell
@@ -37,6 +39,8 @@ date.value:: 2019-07-01
 [%bibitem]
 === The Secure Hash Algorithm Validation System (SHAVS)
 id:: SHAVS
+docid::
+  id::: NIST SHAVS
 
 // <reference anchor="SHAVS">
 //   <front>


### PR DESCRIPTION
All documents compile except for the following errors:

```
bundle exec metanorma compile draft-gold-acvp-sub-kdf135-snmp.adoc
ERROR: draft-gold-acvp-sub-kdf135-snmp.adoc: line 35: include file not found: ./acvp-metanorma/snmp/sections/03-supported.adoc
ERROR: draft-gold-acvp-sub-kdf135-snmp.adoc: line 36: include file not found: ./acvp-metanorma/snmp/sections/04-testtypes.adoc
ERROR: draft-gold-acvp-sub-kdf135-snmp.adoc: line 37: include file not found: ./acvp-metanorma/snmp/sections/XX-requirements-covered.adoc
ERROR: draft-gold-acvp-sub-kdf135-snmp.adoc: line 40: include file not found: ./acvp-metanorma/snmp/sections/05-capabilities.adoc
ERROR: draft-gold-acvp-sub-kdf135-snmp.adoc: line 42: include file not found: ./acvp-metanorma/snmp/sections/06-test-vectors.adoc
ERROR: draft-gold-acvp-sub-kdf135-snmp.adoc: line 43: include file not found: ./acvp-metanorma/snmp/sections/07-responses.adoc
ERROR: draft-gold-acvp-sub-kdf135-snmp.adoc: line 49: include file not found: ./acvp-metanorma/snmp/sections/98-references.adoc
ERROR: draft-gold-acvp-sub-kdf135-snmp.adoc: line 50: include file not found: ./acvp-metanorma/snmp/sections/97-examples.adoc
```


These issues were fixed:

1. In AsciiDoc any empty lines within the document header will not be parsed as header attributes (I know, this is stupid).

This doesn't work:
```adoc
:docfile: draft-gold-acvp-iana.adoc
:role: editor

:mn-document-class: ietf
:mn-output-extensions: xml,rfc,txt,html
```

=> Error:
```
[metanorma] Error: Please specify a standard type: [:standoc, :iso, :iec, :ietf, :gb, :csd, :csa, :generic, :iho, :m3d, :un, :nist, :ogc, :itu].
```

This works:
```adoc
:docfile: draft-gold-acvp-iana.adoc
:role: editor
:mn-document-class: ietf
:mn-output-extensions: xml,rfc,txt,html
```

2. The `:docnumber:` attribute needed to be set for `docName` to be filled... It's a bug (https://github.com/metanorma/metanorma-ietf/issues/82).

3. In AsciiBib entries, the `docid` needs to be provided.

Original:
```adoc
[%bibitem]
=== Automatic Cryptographic Validation Protocol
id:: ACVP
contributor::
contributor.person.name.initial:: B.
```

Provided `docid`:
```adoc
```adoc
[%bibitem]
=== Automatic Cryptographic Validation Protocol
id:: ACVP
docid::
  id::: NIST ACVP
contributor::
contributor.person.name.initial:: B.
```
