### PR TITLE
Remove `nits` extension that is no longer supported

### DIFF
--- a/draft-gold-acvp-sub-kdf135-x942.adoc
+++ b/draft-gold-acvp-sub-kdf135-x942.adoc
@@ -19,7 +19,7 @@
 :email: christopher.celi@nist.gov
 :docfile: draft-celi-acvp-ans-x942.adoc
 :mn-document-class: ietf
-:mn-output-extensions: rfc,txt,html,nits
+:mn-output-extensions: rfc,txt,html
 
 // Singular name of the algorithm
 :spec-algorithm: ANS x9.42 KDF


### PR DESCRIPTION
This will unblock the make process. However, this issue (https://github.com/metanorma/metanorma-ietf/issues/86) still blocks proper deployment. It will be fixed soon.

Update: ~~metanorma/metanorma-ietf#86~~ is now fixed.