### PR TITLE
Corrects KAS schemes description KTS-basic w/ macMethods

### DIFF
--- a/kas/sp800-56br2/sections/05-capabilities.adoc
+++ b/kas/sp800-56br2/sections/05-capabilities.adoc
@@ -72,7 +72,7 @@ KAS Schemes
 
 KTS Schemes
 
-* KTS-OAEP-basic - requires ktsMethod, macMethods
+* KTS-OAEP-basic - requires ktsMethod
 
 * KTS-OAEP-Party_V-confirmation - requires ktsMethod, macMethods
 


### PR DESCRIPTION
- mac methods is not required (or allowed) for KTS-OAEP-basic
- https://github.com/usnistgov/ACVP/issues/938